### PR TITLE
Adds methods to find the clicked word or line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,11 @@ pip-log.txt
 /server_runtime/
 *~
 *.lnk
+
+#################
+## Intelij
+#################
+*.iml
+*.ipr
+*.iws
+out/

--- a/src/main/java/net/afterlifelochie/fontbox/layout/LayoutCalculator.java
+++ b/src/main/java/net/afterlifelochie/fontbox/layout/LayoutCalculator.java
@@ -44,7 +44,7 @@ public class LayoutCalculator {
 	public boolean boxLine(ITracer trace, GLFontMetrics metric, StackedPushbackStringReader text, Page page)
 			throws IOException, FontException {
 		// Calculate some required properties
-		int effectiveWidth = page.height - page.properties.margin_left - page.properties.margin_right;
+		int effectiveWidth = page.width - page.properties.margin_left - page.properties.margin_right;
 		int effectiveHeight = page.getFreeHeight();
 
 		int width_new_line = 0, width_new_word = 0;
@@ -125,17 +125,19 @@ public class LayoutCalculator {
 
 		// Find the maximum height of any characters in the line
 		int height_new_line = page.properties.lineheight_size;
-		for (int i = 0; i < words.size(); i++) {
-			String word = words.get(i);
-			for (int j = 0; j < word.length(); j++) {
-				char c = word.charAt(j);
-				if (c != ' ') {
-					GLGlyphMetric mx = metric.glyphs.get((int) c);
-					if (mx.height > height_new_line)
-						height_new_line = mx.height;
-				}
-			}
-		}
+        for (String word : words)
+        {
+            for (int j = 0; j < word.length(); j++)
+            {
+                char c = word.charAt(j);
+                if (c != ' ')
+                {
+                    GLGlyphMetric mx = metric.glyphs.get((int) c);
+                    if (mx.height > height_new_line)
+                        height_new_line = mx.height;
+                }
+            }
+        }
 
 		// If the line doesn't fit at all, we can't do anything
 		if (height_new_line > effectiveHeight) {

--- a/src/tests/java/net/afterlifelochie/demo/FontBoxHelper.java
+++ b/src/tests/java/net/afterlifelochie/demo/FontBoxHelper.java
@@ -1,0 +1,69 @@
+package net.afterlifelochie.demo;
+
+import net.afterlifelochie.fontbox.GLFont;
+import net.afterlifelochie.fontbox.GLGlyphMetric;
+import net.afterlifelochie.fontbox.layout.Line;
+import net.afterlifelochie.fontbox.layout.Page;
+
+public class FontBoxHelper
+{
+    private static final float scale = 0.44F;
+
+    /**
+     * Get the {@link net.afterlifelochie.fontbox.layout.Line} on the {@link net.afterlifelochie.fontbox.layout.Page}
+     * @param page the given page
+     * @param offset the yPos
+     * @return a line or null if offset is not on a line
+     */
+    public static Line getLine(Page page, float offset)
+    {
+        if (offset < 0) return null;
+        for (Line line : page.lines)
+            if ((offset -= line.line_height * scale) < 0)
+                return line;
+        return null;
+    }
+
+    /**
+     * Get the word at on the {@link net.afterlifelochie.fontbox.layout.Page} written in given {@link net.afterlifelochie.fontbox.GLFont}
+     * @param page the page to work with
+     * @param font the used font to write
+     * @param offsetX the xPos
+     * @param offsetY the yPos
+     * @return the word clicked on or null if no word was there
+     */
+    public static String getWord(Page page, GLFont font, float offsetX, float offsetY)
+    {
+        Line line = getLine(page, offsetY);
+        if (line ==  null) return null;
+        String word = "";
+        for (int i = 0; i < line.line.length(); i++)
+        {
+            if (offsetX < 0)
+            {
+                if (word.isEmpty()) return null;
+                for ( ; i < line.line.length(); i++)
+                {
+                    char c = line.line.charAt(i);
+                    if (c == ' ')
+                        break;
+                    word += c;
+                }
+                return word;
+            }
+            char c = line.line.charAt(i);
+            word += c;
+            if (c == ' ')
+            {
+                offsetX -= line.space_size * scale;
+                word = "";
+                continue;
+            }
+            GLGlyphMetric mx = font.getMetric().glyphs.get((int) c);
+            if (mx == null)
+                continue;
+            offsetX -= mx.width * scale;
+        }
+        return null;
+    }
+}

--- a/src/tests/java/net/afterlifelochie/demo/GuiDemoBook.java
+++ b/src/tests/java/net/afterlifelochie/demo/GuiDemoBook.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import net.afterlifelochie.fontbox.layout.Line;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
@@ -21,6 +22,7 @@ import net.minecraft.util.ResourceLocation;
 public class GuiDemoBook extends GuiScreen {
 	private Page[] pages;
 	private int currentPage = 0;
+    private int top, left;
 
 	public GuiDemoBook() {
 		this(null);
@@ -40,7 +42,7 @@ public class GuiDemoBook extends GuiScreen {
 			reader.close();
 
 			FontboxClient client = (FontboxClient) FontboxDemoMod.proxy;
-			PageProperties properties = new PageProperties(325, 425).bothMargin(2).lineheightSize(1).spaceSize(10);
+			PageProperties properties = new PageProperties(350, 450).bothMargin(2).lineheightSize(1).spaceSize(10);
 			this.pages = client.fontCalculator.boxParagraph(Fontbox.tracer(), Fontbox.fromName("Daniel"),
 					fileData.toString(), properties);
 		} catch (IOException ioex) {
@@ -70,7 +72,7 @@ public class GuiDemoBook extends GuiScreen {
 		super.drawScreen(par1, par2, par3);
 		GL11.glPushMatrix();
 		GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-		GL11.glTranslatef(width / 2 - 200, height / 2 - 110, 0.0f);
+		GL11.glTranslatef(left = width / 2 - 200, top = height / 2 - 110, 0.0f);
 		useTexture("noteback");
 		drawTexturedRectUV(0, 0, 400, 220, 0, 0, 1083.0f / 1111.0f, 847.0f / 1024.0f);
 
@@ -116,8 +118,19 @@ public class GuiDemoBook extends GuiScreen {
 
 	@Override
 	protected void mouseClicked(int par1, int par2, int par3) {
+        int mouseX = par1 - left;
+        int mouseY = par2 - top;
+        if (mouseX < 200)
+        {
+            if (this.pages.length > currentPage)
+                System.out.println(FontBoxHelper.getWord(this.pages[currentPage], Fontbox.fromName("Daniel"), mouseX - 18, mouseY - 12));
+        }
+        else
+        {
+            if (this.pages.length > currentPage + 1)
+                System.out.println(FontBoxHelper.getWord(this.pages[currentPage + 1], Fontbox.fromName("Ampersand"), mouseX - 204, mouseY - 12));
+        }
 		super.mouseClicked(par1, par2, par3);
-
 	}
 
 	private void useTexture(String name) {


### PR DESCRIPTION
This also fixes an issue regarding the render width. For some reason it was using the height as width during the render code it is always rendered squares. I accidentally reformatted a small piece of code in fed4e94199a932c8f6208dd0f3b94c5af51aa000 . The added functions will return the Line object or a specific word when click. The reason for these are linking that way there could be a map of links in the book that when a word is click the player can be navigated to the correct page.
