### PR TITLE
Small fix in book GUI and start of a fix for a bigger issue

### DIFF
--- a/src/main/java/net/afterlifelochie/fontbox/document/Element.java
+++ b/src/main/java/net/afterlifelochie/fontbox/document/Element.java
@@ -279,6 +279,21 @@ public abstract class Element {
 						width_new_word += mx.width;
 						// Push the character on the stack
 						chars.add(c);
+                        
+                        // Find out if the word is bigger then the line
+                        if (words.size() == 0 && bounds.width < width_new_word)
+                        {
+                            c = text.next();
+                            // See if end of word or end of buffer
+                            if (c == ' ' || c == '\r' || c == '\n' || c == 0)
+                            {
+                                words.add("[I was to big]"); // TODO: Proper handling
+                                trace.trace("Element.boxText", "wordBiggerThenLine", chars.toString());
+                                chars.clear();
+                                break; // hard EOL
+                            }
+                            text.rewind(1);
+                        }
 					} else {
 						trace.trace("Element.boxText", "badChar", c);
 						throw new LayoutException("Unable to configure glyph " + c);

--- a/src/main/java/net/afterlifelochie/fontbox/render/BookGUI.java
+++ b/src/main/java/net/afterlifelochie/fontbox/render/BookGUI.java
@@ -272,7 +272,7 @@ public abstract class BookGUI extends GuiScreen {
 		for (int i = 0; i < mode.pages; i++) {
 			Layout where = layout[i];
 			int which = ptr + i;
-			if (pages.size() <= which)
+			if (pages == null || pages.size() <= which)
 				break;
 			Page page = pages.get(ptr + i);
 			int mouseX = mx - where.x, mouseY = my - where.y;


### PR DESCRIPTION
When passing `Element.boxText` a word that is bigger then the actual line it will fall in an endless loop. I started a small fix while getting Minechem to work but it needs more thought as for word breaks (eg. on hyphens or points on the word). I can to this crash because some text wasn't localized yet and was something like `journal.chemicals.elements.ununoctium.text`` and that didn't fit the width of the line.

The fix in BookGUI is just to prevent a hard crash when pages get miss initialized and return null and set the pages field to null.
